### PR TITLE
feat: TypeScript SDK (@sharkauth/js)

### DIFF
--- a/sdk/.gitignore
+++ b/sdk/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@sharkauth/js",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for SharkAuth — zero-dependency, isomorphic auth client",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "lint": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^2.0.0"
+  },
+  "keywords": [
+    "auth",
+    "authentication",
+    "sharkauth",
+    "passkeys",
+    "webauthn",
+    "mfa",
+    "oauth",
+    "sdk"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shark-auth/shark"
+  }
+}

--- a/sdk/src/__tests__/client.test.ts
+++ b/sdk/src/__tests__/client.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi } from "vitest";
+import { createSharkAuth, SharkError } from "../index.js";
+
+function mockFetch(status: number, body: unknown, headers?: Headers) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    text: () => Promise.resolve(JSON.stringify(body)),
+    json: () => Promise.resolve(body),
+    headers: headers ?? new Headers(),
+  });
+}
+
+describe("createSharkAuth", () => {
+  it("creates an instance with all sub-clients", () => {
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080" });
+    expect(shark.mfa).toBeDefined();
+    expect(shark.passkey).toBeDefined();
+    expect(shark.oauth).toBeDefined();
+    expect(shark.magicLink).toBeDefined();
+    expect(shark.login).toBeTypeOf("function");
+    expect(shark.signup).toBeTypeOf("function");
+    expect(shark.logout).toBeTypeOf("function");
+    expect(shark.me).toBeTypeOf("function");
+    expect(shark.check).toBeTypeOf("function");
+  });
+});
+
+describe("auth", () => {
+  it("signup returns user", async () => {
+    const user = { id: "usr_123", email: "test@test.com", mfaEnabled: false };
+    const fetch = mockFetch(201, user);
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    const result = await shark.signup({ email: "test@test.com", password: "password123" });
+    expect(result).toEqual(user);
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:8080/api/v1/auth/signup",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "include",
+      }),
+    );
+  });
+
+  it("login returns user when MFA not enabled", async () => {
+    const user = { id: "usr_123", email: "test@test.com", mfaEnabled: false };
+    const fetch = mockFetch(200, user);
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    const result = await shark.login({ email: "test@test.com", password: "password123" });
+    expect(result.mfaRequired).toBe(false);
+    if (!result.mfaRequired) {
+      expect(result.user.id).toBe("usr_123");
+    }
+  });
+
+  it("login returns mfaRequired when MFA is enabled", async () => {
+    const fetch = mockFetch(200, { mfaRequired: true });
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    const result = await shark.login({ email: "test@test.com", password: "password123" });
+    expect(result.mfaRequired).toBe(true);
+  });
+
+  it("login throws SharkError on invalid credentials", async () => {
+    const fetch = mockFetch(401, { error: "invalid_credentials", message: "Invalid email or password" });
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    await expect(shark.login({ email: "test@test.com", password: "wrong" }))
+      .rejects.toThrow(SharkError);
+
+    try {
+      await shark.login({ email: "test@test.com", password: "wrong" });
+    } catch (err) {
+      expect(err).toBeInstanceOf(SharkError);
+      expect((err as SharkError).status).toBe(401);
+      expect((err as SharkError).code).toBe("invalid_credentials");
+    }
+  });
+
+  it("me returns user", async () => {
+    const user = { id: "usr_123", email: "test@test.com", mfaEnabled: false };
+    const fetch = mockFetch(200, user);
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    const result = await shark.me();
+    expect(result.id).toBe("usr_123");
+  });
+
+  it("me throws 403 when MFA incomplete", async () => {
+    const fetch = mockFetch(403, { error: "mfa_required", message: "MFA verification required" });
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    await expect(shark.me()).rejects.toThrow(SharkError);
+  });
+
+  it("logout calls POST /logout", async () => {
+    const fetch = mockFetch(200, {});
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    await shark.logout();
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:8080/api/v1/auth/logout",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});
+
+describe("check", () => {
+  it("returns authenticated: true when session is valid", async () => {
+    const user = { id: "usr_123", email: "test@test.com", mfaEnabled: false };
+    const fetch = mockFetch(200, user);
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    const result = await shark.check();
+    expect(result.authenticated).toBe(true);
+    expect(result.user?.id).toBe("usr_123");
+  });
+
+  it("returns authenticated: false on 401", async () => {
+    const fetch = mockFetch(401, { error: "unauthorized", message: "No valid session" });
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    const result = await shark.check();
+    expect(result.authenticated).toBe(false);
+    expect(result.user).toBeNull();
+  });
+
+  it("returns authenticated: false on 403 (MFA incomplete)", async () => {
+    const fetch = mockFetch(403, { error: "mfa_required", message: "MFA verification required" });
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    const result = await shark.check();
+    expect(result.authenticated).toBe(false);
+    expect(result.user).toBeNull();
+  });
+
+  it("rethrows non-auth errors", async () => {
+    const fetch = mockFetch(500, { error: "internal_error", message: "Internal server error" });
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    await expect(shark.check()).rejects.toThrow(SharkError);
+  });
+});
+
+describe("mfa", () => {
+  it("enroll returns secret and qr_uri", async () => {
+    const fetch = mockFetch(200, { secret: "JBSWY3DPEHPK3PXP", qr_uri: "otpauth://totp/..." });
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    const result = await shark.mfa.enroll();
+    expect(result.secret).toBe("JBSWY3DPEHPK3PXP");
+    expect(result.qr_uri).toContain("otpauth://");
+  });
+
+  it("verify returns recovery codes", async () => {
+    const fetch = mockFetch(200, { mfa_enabled: true, recovery_codes: ["abc123", "def456"] });
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    const result = await shark.mfa.verify({ code: "123456" });
+    expect(result.mfa_enabled).toBe(true);
+    expect(result.recovery_codes).toHaveLength(2);
+  });
+
+  it("challenge upgrades session and returns user", async () => {
+    const user = { id: "usr_123", email: "test@test.com", mfaEnabled: true };
+    const fetch = mockFetch(200, user);
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    const result = await shark.mfa.challenge({ code: "123456" });
+    expect(result.id).toBe("usr_123");
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:8080/api/v1/auth/mfa/challenge",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("challenge throws on invalid code", async () => {
+    const fetch = mockFetch(401, { error: "invalid_code", message: "Invalid TOTP code" });
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    await expect(shark.mfa.challenge({ code: "000000" })).rejects.toThrow(SharkError);
+  });
+
+  it("useRecoveryCode works as MFA alternative", async () => {
+    const user = { id: "usr_123", email: "test@test.com", mfaEnabled: true };
+    const fetch = mockFetch(200, user);
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    const result = await shark.mfa.useRecoveryCode({ code: "abc123" });
+    expect(result.id).toBe("usr_123");
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:8080/api/v1/auth/mfa/recovery",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});
+
+describe("oauth", () => {
+  it("getURL returns correct redirect URL", () => {
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080" });
+
+    expect(shark.oauth.getURL("google")).toBe("http://localhost:8080/api/v1/auth/oauth/google");
+    expect(shark.oauth.getURL("github")).toBe("http://localhost:8080/api/v1/auth/oauth/github");
+    expect(shark.oauth.getURL("apple")).toBe("http://localhost:8080/api/v1/auth/oauth/apple");
+    expect(shark.oauth.getURL("discord")).toBe("http://localhost:8080/api/v1/auth/oauth/discord");
+  });
+
+  it("strips trailing slash from baseURL", () => {
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080/" });
+    expect(shark.oauth.getURL("google")).toBe("http://localhost:8080/api/v1/auth/oauth/google");
+  });
+});
+
+describe("magicLink", () => {
+  it("send calls correct endpoint", async () => {
+    const fetch = mockFetch(200, { message: "Check your email" });
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    await shark.magicLink.send({ email: "test@test.com" });
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:8080/api/v1/auth/magic-link/send",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ email: "test@test.com" }),
+      }),
+    );
+  });
+});
+
+describe("password reset", () => {
+  it("sendPasswordReset calls correct endpoint", async () => {
+    const fetch = mockFetch(200, { message: "If an account with that email exists..." });
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    await shark.sendPasswordReset({ email: "test@test.com" });
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:8080/api/v1/auth/password/send-reset-link",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("resetPassword calls correct endpoint", async () => {
+    const fetch = mockFetch(200, { message: "Password has been reset successfully" });
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    await shark.resetPassword({ token: "abc123", password: "newpassword" });
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:8080/api/v1/auth/password/reset",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});
+
+describe("HttpClient", () => {
+  it("includes credentials: include on every request", async () => {
+    const fetch = mockFetch(200, {});
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    await shark.me();
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+
+  it("sets Content-Type: application/json", async () => {
+    const fetch = mockFetch(200, {});
+    const shark = createSharkAuth({ baseURL: "http://localhost:8080", fetch });
+
+    await shark.logout();
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ "Content-Type": "application/json" }),
+      }),
+    );
+  });
+});

--- a/sdk/src/auth.ts
+++ b/sdk/src/auth.ts
@@ -1,0 +1,76 @@
+import type { HttpClient } from "./client.js";
+import type {
+  ChangePasswordParams,
+  LoginMFAResult,
+  LoginParams,
+  LoginResult,
+  PasswordResetParams,
+  PasswordResetSendParams,
+  SignupParams,
+  User,
+} from "./types.js";
+
+export class AuthClient {
+  constructor(private http: HttpClient) {}
+
+  /** Create a new account and automatically sign in. */
+  async signup(params: SignupParams): Promise<User> {
+    return this.http.post<User>("/api/v1/auth/signup", params);
+  }
+
+  /**
+   * Sign in with email and password.
+   *
+   * If MFA is enabled on the account, the result will have `mfaRequired: true`.
+   * You must then call `mfa.challenge()` or `mfa.useRecoveryCode()` to complete login.
+   *
+   * @example
+   * ```ts
+   * const result = await auth.login({ email, password });
+   * if (result.mfaRequired) {
+   *   // show TOTP input
+   *   const user = await auth.mfa.challenge({ code: totpCode });
+   * } else {
+   *   // fully authenticated
+   *   console.log(result.user);
+   * }
+   * ```
+   */
+  async login(params: LoginParams): Promise<LoginResult | LoginMFAResult> {
+    const data = await this.http.post<User & { mfaRequired?: boolean }>(
+      "/api/v1/auth/login",
+      params,
+    );
+
+    if (data.mfaRequired) {
+      return { mfaRequired: true };
+    }
+
+    return { mfaRequired: false, user: data };
+  }
+
+  /** Sign out and destroy the current session. */
+  async logout(): Promise<void> {
+    await this.http.post("/api/v1/auth/logout");
+  }
+
+  /** Get the currently authenticated user. Throws if not authenticated or MFA incomplete. */
+  async me(): Promise<User> {
+    return this.http.get<User>("/api/v1/auth/me");
+  }
+
+  /** Send a password reset email. Always succeeds (doesn't leak email existence). */
+  async sendPasswordReset(params: PasswordResetSendParams): Promise<void> {
+    await this.http.post("/api/v1/auth/password/send-reset-link", params);
+  }
+
+  /** Reset password using a token from the reset email. */
+  async resetPassword(params: PasswordResetParams): Promise<void> {
+    await this.http.post("/api/v1/auth/password/reset", params);
+  }
+
+  /** Change password for the currently authenticated user. Requires MFA-completed session. */
+  async changePassword(params: ChangePasswordParams): Promise<void> {
+    await this.http.post("/api/v1/auth/password/change", params);
+  }
+}

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -1,0 +1,84 @@
+import type { SharkAuthConfig, SharkErrorBody } from "./types.js";
+
+export class SharkError extends Error {
+  public readonly status: number;
+  public readonly code: string;
+
+  constructor(status: number, body: SharkErrorBody) {
+    super(body.message);
+    this.name = "SharkError";
+    this.status = status;
+    this.code = body.error;
+  }
+}
+
+export class HttpClient {
+  private baseURL: string;
+  private fetchFn: typeof fetch;
+
+  constructor(config: SharkAuthConfig) {
+    // Strip trailing slash
+    this.baseURL = config.baseURL.replace(/\/+$/, "");
+    this.fetchFn = config.fetch ?? globalThis.fetch.bind(globalThis);
+  }
+
+  async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    headers?: Record<string, string>,
+  ): Promise<T> {
+    const url = `${this.baseURL}${path}`;
+
+    const init: RequestInit = {
+      method,
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+        ...headers,
+      },
+    };
+
+    if (body !== undefined) {
+      init.body = JSON.stringify(body);
+    }
+
+    const res = await this.fetchFn(url, init);
+
+    if (!res.ok) {
+      let errorBody: SharkErrorBody;
+      try {
+        errorBody = await res.json();
+      } catch {
+        errorBody = { error: "unknown", message: res.statusText };
+      }
+      throw new SharkError(res.status, errorBody);
+    }
+
+    // Handle empty responses (logout, etc.)
+    const text = await res.text();
+    if (!text) return {} as T;
+    return JSON.parse(text) as T;
+  }
+
+  get<T>(path: string, headers?: Record<string, string>): Promise<T> {
+    return this.request<T>("GET", path, undefined, headers);
+  }
+
+  post<T>(path: string, body?: unknown, headers?: Record<string, string>): Promise<T> {
+    return this.request<T>("POST", path, body, headers);
+  }
+
+  patch<T>(path: string, body?: unknown, headers?: Record<string, string>): Promise<T> {
+    return this.request<T>("PATCH", path, body, headers);
+  }
+
+  del<T>(path: string, body?: unknown, headers?: Record<string, string>): Promise<T> {
+    return this.request<T>("DELETE", path, body, headers);
+  }
+
+  /** Returns the full URL for a given path (used for OAuth redirects). */
+  url(path: string): string {
+    return `${this.baseURL}${path}`;
+  }
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,0 +1,151 @@
+import { HttpClient } from "./client.js";
+import { AuthClient } from "./auth.js";
+import { MFAClient } from "./mfa.js";
+import { PasskeyClient } from "./passkey.js";
+import { OAuthClient } from "./oauth.js";
+import { MagicLinkClient } from "./magic-link.js";
+import type { SharkAuthConfig, User } from "./types.js";
+import { SharkError } from "./client.js";
+
+export class SharkAuth {
+  private authClient: AuthClient;
+
+  /** Multi-factor authentication (TOTP). */
+  public readonly mfa: MFAClient;
+  /** Passkey / WebAuthn authentication. */
+  public readonly passkey: PasskeyClient;
+  /** Social OAuth login (Google, GitHub, Apple, Discord). */
+  public readonly oauth: OAuthClient;
+  /** Passwordless magic link login. */
+  public readonly magicLink: MagicLinkClient;
+
+  constructor(config: SharkAuthConfig) {
+    const http = new HttpClient(config);
+    this.authClient = new AuthClient(http);
+    this.mfa = new MFAClient(http);
+    this.passkey = new PasskeyClient(http);
+    this.oauth = new OAuthClient(http);
+    this.magicLink = new MagicLinkClient(http);
+
+    // Bind auth methods to this instance
+    this.signup = this.authClient.signup.bind(this.authClient);
+    this.login = this.authClient.login.bind(this.authClient);
+    this.logout = this.authClient.logout.bind(this.authClient);
+    this.me = this.authClient.me.bind(this.authClient);
+    this.sendPasswordReset = this.authClient.sendPasswordReset.bind(this.authClient);
+    this.resetPassword = this.authClient.resetPassword.bind(this.authClient);
+    this.changePassword = this.authClient.changePassword.bind(this.authClient);
+  }
+
+  /** Create a new account and automatically sign in. */
+  signup: AuthClient["signup"];
+
+  /**
+   * Sign in with email and password.
+   *
+   * Returns `{ mfaRequired: false, user }` on success, or
+   * `{ mfaRequired: true }` if MFA verification is needed.
+   *
+   * When MFA is required, call `shark.mfa.challenge({ code })` to complete login.
+   *
+   * @example
+   * ```ts
+   * const result = await shark.login({ email, password });
+   * if (result.mfaRequired) {
+   *   const user = await shark.mfa.challenge({ code: totpCode });
+   * } else {
+   *   console.log("Logged in:", result.user);
+   * }
+   * ```
+   */
+  login: AuthClient["login"];
+
+  /** Sign out and destroy the current session. */
+  logout: AuthClient["logout"];
+
+  /** Get the current user. Throws `SharkError` (403) if MFA is incomplete. */
+  me: AuthClient["me"];
+
+  /** Send a password reset email. */
+  sendPasswordReset: AuthClient["sendPasswordReset"];
+
+  /** Reset password using a token from the reset email. */
+  resetPassword: AuthClient["resetPassword"];
+
+  /** Change password (requires current password + MFA-completed session). */
+  changePassword: AuthClient["changePassword"];
+
+  /**
+   * Check if the user is currently authenticated.
+   * Returns the user if authenticated, or `null` if not (without throwing).
+   */
+  async check(): Promise<{ authenticated: true; user: User } | { authenticated: false; user: null }> {
+    try {
+      const user = await this.authClient.me();
+      return { authenticated: true, user };
+    } catch (err) {
+      if (err instanceof SharkError && (err.status === 401 || err.status === 403)) {
+        return { authenticated: false, user: null };
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Create a SharkAuth client instance.
+ *
+ * @example
+ * ```ts
+ * import { createSharkAuth } from "@sharkauth/js";
+ *
+ * const shark = createSharkAuth({
+ *   baseURL: "https://auth.myapp.com",
+ * });
+ *
+ * // Sign up
+ * const user = await shark.signup({ email: "user@example.com", password: "secret123" });
+ *
+ * // Login with MFA handling
+ * const result = await shark.login({ email, password });
+ * if (result.mfaRequired) {
+ *   const user = await shark.mfa.challenge({ code: "123456" });
+ * }
+ *
+ * // Passkey login
+ * const user = await shark.passkey.login();
+ *
+ * // OAuth redirect
+ * window.location.href = shark.oauth.getURL("google");
+ *
+ * // Magic link
+ * await shark.magicLink.send({ email: "user@example.com" });
+ *
+ * // Check auth state (never throws on 401/403)
+ * const { authenticated, user } = await shark.check();
+ * ```
+ */
+export function createSharkAuth(config: SharkAuthConfig): SharkAuth {
+  return new SharkAuth(config);
+}
+
+// Re-export types and error
+export { SharkError } from "./client.js";
+export type {
+  SharkAuthConfig,
+  User,
+  SignupParams,
+  LoginParams,
+  LoginResult,
+  LoginMFAResult,
+  PasswordResetSendParams,
+  PasswordResetParams,
+  ChangePasswordParams,
+  MFAEnrollResult,
+  MFAVerifyResult,
+  MFACodeParams,
+  PasskeyCredential,
+  PasskeyRegisterResult,
+  OAuthProvider,
+  MagicLinkSendParams,
+} from "./types.js";

--- a/sdk/src/magic-link.ts
+++ b/sdk/src/magic-link.ts
@@ -1,0 +1,17 @@
+import type { HttpClient } from "./client.js";
+import type { MagicLinkSendParams } from "./types.js";
+
+export class MagicLinkClient {
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Send a magic link to the given email address.
+   * The user clicks the link in their email to authenticate.
+   *
+   * Always succeeds (doesn't reveal whether the email exists).
+   * Rate-limited to 1 request per 60 seconds per email.
+   */
+  async send(params: MagicLinkSendParams): Promise<void> {
+    await this.http.post("/api/v1/auth/magic-link/send", params);
+  }
+}

--- a/sdk/src/mfa.ts
+++ b/sdk/src/mfa.ts
@@ -1,0 +1,61 @@
+import type { HttpClient } from "./client.js";
+import type {
+  MFACodeParams,
+  MFAEnrollResult,
+  MFAVerifyResult,
+  User,
+} from "./types.js";
+
+export class MFAClient {
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Start MFA enrollment. Returns the TOTP secret and a QR code URI.
+   * Requires a fully authenticated session (MFA already passed or not enabled).
+   */
+  async enroll(): Promise<MFAEnrollResult> {
+    return this.http.post<MFAEnrollResult>("/api/v1/auth/mfa/enroll");
+  }
+
+  /**
+   * Confirm MFA setup with the first TOTP code from the authenticator app.
+   * Returns recovery codes — the user should save these.
+   */
+  async verify(params: MFACodeParams): Promise<MFAVerifyResult> {
+    return this.http.post<MFAVerifyResult>("/api/v1/auth/mfa/verify", params);
+  }
+
+  /**
+   * Submit a TOTP code to complete login when MFA is required.
+   * Call this after `login()` returns `{ mfaRequired: true }`.
+   * On success, the session is upgraded and the user is returned.
+   */
+  async challenge(params: MFACodeParams): Promise<User> {
+    return this.http.post<User>("/api/v1/auth/mfa/challenge", params);
+  }
+
+  /**
+   * Use a recovery code to complete login when MFA is required.
+   * Call this after `login()` returns `{ mfaRequired: true }` if the user lost their device.
+   * Recovery codes are single-use.
+   */
+  async useRecoveryCode(params: MFACodeParams): Promise<User> {
+    return this.http.post<User>("/api/v1/auth/mfa/recovery", params);
+  }
+
+  /**
+   * Disable MFA. Requires a current TOTP code for confirmation.
+   * Requires a fully authenticated session.
+   */
+  async disable(params: MFACodeParams): Promise<void> {
+    await this.http.del("/api/v1/auth/mfa", params);
+  }
+
+  /**
+   * Regenerate recovery codes. Invalidates all previous codes.
+   * Requires a fully authenticated session with MFA enabled.
+   */
+  async regenerateRecoveryCodes(): Promise<{ recovery_codes: string[] }> {
+    return this.http.get<{ recovery_codes: string[] }>("/api/v1/auth/mfa/recovery-codes");
+  }
+}

--- a/sdk/src/oauth.ts
+++ b/sdk/src/oauth.ts
@@ -1,0 +1,19 @@
+import type { HttpClient } from "./client.js";
+import type { OAuthProvider } from "./types.js";
+
+export class OAuthClient {
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Get the OAuth redirect URL for a provider.
+   * Navigate the user to this URL to start the OAuth flow.
+   *
+   * @example
+   * ```ts
+   * window.location.href = auth.oauth.getURL("google");
+   * ```
+   */
+  getURL(provider: OAuthProvider): string {
+    return this.http.url(`/api/v1/auth/oauth/${provider}`);
+  }
+}

--- a/sdk/src/passkey.ts
+++ b/sdk/src/passkey.ts
@@ -1,0 +1,169 @@
+import type { HttpClient } from "./client.js";
+import type { PasskeyCredential, PasskeyRegisterResult, User } from "./types.js";
+
+/**
+ * Base64url encoding/decoding for WebAuthn ArrayBuffer <-> string conversion.
+ * These work in both browser and Node.js 18+ (via globalThis.btoa/atob).
+ */
+function toBase64URL(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fromBase64URL(str: string): ArrayBuffer {
+  const base64 = str.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+export class PasskeyClient {
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Register a new passkey for the current user.
+   * This triggers the browser's WebAuthn dialog (Touch ID, Windows Hello, security key, etc).
+   * Requires an authenticated session.
+   */
+  async register(): Promise<PasskeyRegisterResult> {
+    // Step 1: Get registration options from server
+    const { publicKey, challengeKey } = await this.http.post<{
+      publicKey: PublicKeyCredentialCreationOptions;
+      challengeKey: string;
+    }>("/api/v1/auth/passkey/register/begin");
+
+    // Step 2: Decode base64url fields to ArrayBuffers for the browser API
+    const options: PublicKeyCredentialCreationOptions = {
+      ...publicKey,
+      challenge: fromBase64URL(publicKey.challenge as unknown as string),
+      user: {
+        ...publicKey.user,
+        id: fromBase64URL(publicKey.user.id as unknown as string),
+      },
+    };
+
+    if (publicKey.excludeCredentials) {
+      options.excludeCredentials = publicKey.excludeCredentials.map((cred) => ({
+        ...cred,
+        id: fromBase64URL(cred.id as unknown as string),
+      }));
+    }
+
+    // Step 3: Browser WebAuthn dialog
+    const credential = (await navigator.credentials.create({
+      publicKey: options,
+    })) as PublicKeyCredential | null;
+
+    if (!credential) {
+      throw new Error("Passkey registration was cancelled");
+    }
+
+    const response = credential.response as AuthenticatorAttestationResponse;
+
+    // Step 4: Send attestation to server
+    const body = {
+      id: credential.id,
+      rawId: toBase64URL(credential.rawId),
+      type: credential.type,
+      response: {
+        attestationObject: toBase64URL(response.attestationObject),
+        clientDataJSON: toBase64URL(response.clientDataJSON),
+      },
+    };
+
+    return this.http.post<PasskeyRegisterResult>(
+      "/api/v1/auth/passkey/register/finish",
+      body,
+      { "X-Challenge-Key": challengeKey },
+    );
+  }
+
+  /**
+   * Sign in with a passkey.
+   * This triggers the browser's WebAuthn dialog for authentication.
+   * Passkey login bypasses MFA (passkeys satisfy AAL2).
+   *
+   * @param email - Optional. If provided, limits to that user's passkeys.
+   *                If omitted, uses discoverable credentials (resident keys).
+   */
+  async login(email?: string): Promise<User> {
+    // Step 1: Get assertion options from server
+    const beginBody = email ? { email } : undefined;
+    const { publicKey, challengeKey } = await this.http.post<{
+      publicKey: PublicKeyCredentialRequestOptions;
+      challengeKey: string;
+    }>("/api/v1/auth/passkey/login/begin", beginBody);
+
+    // Step 2: Decode base64url fields
+    const options: PublicKeyCredentialRequestOptions = {
+      ...publicKey,
+      challenge: fromBase64URL(publicKey.challenge as unknown as string),
+    };
+
+    if (publicKey.allowCredentials) {
+      options.allowCredentials = publicKey.allowCredentials.map((cred) => ({
+        ...cred,
+        id: fromBase64URL(cred.id as unknown as string),
+      }));
+    }
+
+    // Step 3: Browser WebAuthn dialog
+    const credential = (await navigator.credentials.get({
+      publicKey: options,
+    })) as PublicKeyCredential | null;
+
+    if (!credential) {
+      throw new Error("Passkey authentication was cancelled");
+    }
+
+    const response = credential.response as AuthenticatorAssertionResponse;
+
+    // Step 4: Send assertion to server
+    const body = {
+      id: credential.id,
+      rawId: toBase64URL(credential.rawId),
+      type: credential.type,
+      response: {
+        authenticatorData: toBase64URL(response.authenticatorData),
+        clientDataJSON: toBase64URL(response.clientDataJSON),
+        signature: toBase64URL(response.signature),
+        userHandle: response.userHandle ? toBase64URL(response.userHandle) : undefined,
+      },
+    };
+
+    return this.http.post<User>(
+      "/api/v1/auth/passkey/login/finish",
+      body,
+      { "X-Challenge-Key": challengeKey },
+    );
+  }
+
+  /** List the current user's registered passkeys. */
+  async list(): Promise<PasskeyCredential[]> {
+    const data = await this.http.get<{ credentials: PasskeyCredential[] }>(
+      "/api/v1/auth/passkey/credentials",
+    );
+    return data.credentials;
+  }
+
+  /** Delete a passkey by ID. */
+  async remove(credentialId: string): Promise<void> {
+    await this.http.del(`/api/v1/auth/passkey/credentials/${credentialId}`);
+  }
+
+  /** Rename a passkey. */
+  async rename(credentialId: string, name: string): Promise<PasskeyCredential> {
+    return this.http.patch<PasskeyCredential>(
+      `/api/v1/auth/passkey/credentials/${credentialId}`,
+      { name },
+    );
+  }
+}

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -1,0 +1,106 @@
+// ── Configuration ──
+
+export interface SharkAuthConfig {
+  /** Base URL of the SharkAuth server (e.g. "https://auth.myapp.com" or "http://localhost:8080") */
+  baseURL: string;
+  /** Custom fetch implementation. Defaults to globalThis.fetch. */
+  fetch?: typeof fetch;
+}
+
+// ── User ──
+
+export interface User {
+  id: string;
+  email: string;
+  emailVerified: boolean;
+  name?: string;
+  avatarUrl?: string;
+  mfaEnabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ── Auth ──
+
+export interface SignupParams {
+  email: string;
+  password: string;
+  name?: string;
+}
+
+export interface LoginParams {
+  email: string;
+  password: string;
+}
+
+export interface LoginResult {
+  mfaRequired: false;
+  user: User;
+}
+
+export interface LoginMFAResult {
+  mfaRequired: true;
+}
+
+export interface PasswordResetSendParams {
+  email: string;
+}
+
+export interface PasswordResetParams {
+  token: string;
+  password: string;
+}
+
+export interface ChangePasswordParams {
+  current_password: string;
+  new_password: string;
+}
+
+// ── MFA ──
+
+export interface MFAEnrollResult {
+  secret: string;
+  qr_uri: string;
+}
+
+export interface MFAVerifyResult {
+  mfa_enabled: true;
+  recovery_codes: string[];
+}
+
+export interface MFACodeParams {
+  code: string;
+}
+
+// ── Passkeys ──
+
+export interface PasskeyCredential {
+  id: string;
+  name?: string;
+  transports: string;
+  backed_up: boolean;
+  created_at: string;
+  last_used_at?: string;
+}
+
+export interface PasskeyRegisterResult {
+  credential_id: string;
+  name: string;
+}
+
+// ── OAuth ──
+
+export type OAuthProvider = "google" | "github" | "apple" | "discord";
+
+// ── Magic Link ──
+
+export interface MagicLinkSendParams {
+  email: string;
+}
+
+// ── Errors ──
+
+export interface SharkErrorBody {
+  error: string;
+  message: string;
+}

--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/sdk/tsup.config.ts
+++ b/sdk/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  minify: false,
+  target: "es2020",
+});


### PR DESCRIPTION
## Summary

- Zero-dependency, isomorphic TypeScript SDK for SharkAuth (`@sharkauth/js`)
- Fetch-based HTTP client with `credentials: 'include'` on every request — cookie auth just works
- **MFA state machine handled by the SDK** — `login()` returns `{ mfaRequired: true }` so devs can't accidentally skip the TOTP step (the exact bug that prompted this)
- Passkey helpers wrap the WebAuthn browser API with base64url ↔ ArrayBuffer conversion
- OAuth helper returns redirect URLs for Google/GitHub/Apple/Discord
- `shark.check()` returns `{ authenticated, user }` without throwing on 401/403
- 24 tests (vitest), ESM + CJS + .d.ts build (tsup)

## API surface

```ts
const shark = createSharkAuth({ baseURL: 'http://localhost:8080' });

// Auth
await shark.signup({ email, password, name });
const result = await shark.login({ email, password });
if (result.mfaRequired) {
  await shark.mfa.challenge({ code: totpCode });
}
await shark.logout();
const user = await shark.me();
const { authenticated, user } = await shark.check();

// Passkeys
await shark.passkey.register();
await shark.passkey.login();

// OAuth
window.location.href = shark.oauth.getURL('google');

// Magic links
await shark.magicLink.send({ email });

// MFA management
const { secret, qr_uri } = await shark.mfa.enroll();
await shark.mfa.verify({ code });
await shark.mfa.disable({ code });
```

## Test plan

- [x] `npm run typecheck` — zero errors
- [x] `npx vitest run` — 24/24 tests pass
- [x] `npx tsup` — builds ESM + CJS + .d.ts
- [ ] Integration test against running SharkAuth binary (manual)
- [ ] Test passkey flows in browser (requires WebAuthn API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)