### PR TITLE
Search admin users by id

### DIFF
--- a/internal/api/user_handlers_test.go
+++ b/internal/api/user_handlers_test.go
@@ -94,6 +94,45 @@ func TestAdminListUsers_SnakeCaseShape(t *testing.T) {
 	}
 }
 
+func TestAdminListUsers_SearchMatchesUserID(t *testing.T) {
+	ts := testutil.NewTestServer(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	u := &storage.User{
+		ID:        "usr_agent_owner_123",
+		Email:     "agent-owner@example.com",
+		HashType:  "argon2id",
+		Metadata:  "{}",
+		CreatedAt: now.Format(time.RFC3339),
+		UpdatedAt: now.Format(time.RFC3339),
+	}
+	if err := ts.Store.CreateUser(ctx, u); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := ts.GetWithAdminKey("/api/v1/users?search=usr_agent_owner_123")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Users []struct {
+			ID    string `json:"id"`
+			Email string `json:"email"`
+		} `json:"users"`
+		Total int `json:"total"`
+	}
+	ts.DecodeJSON(resp, &body)
+
+	if body.Total != 1 {
+		t.Fatalf("total: got %d, want 1", body.Total)
+	}
+	if len(body.Users) != 1 || body.Users[0].ID != "usr_agent_owner_123" {
+		t.Fatalf("users: got %+v, want usr_agent_owner_123", body.Users)
+	}
+}
+
 // TestAdminGetUser_SnakeCaseShape verifies the single-user endpoint also
 // emits snake_case keys.
 func TestAdminGetUser_SnakeCaseShape(t *testing.T) {

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -257,9 +257,9 @@ func userListConditions(opts ListUsersOpts) ([]string, []interface{}) {
 		args = append(args, opts.RoleID)
 	}
 	if opts.Search != "" {
-		conditions = append(conditions, `(email LIKE ? OR name LIKE ?)`)
+		conditions = append(conditions, `(id LIKE ? OR email LIKE ? OR name LIKE ?)`)
 		search := "%" + opts.Search + "%"
-		args = append(args, search, search)
+		args = append(args, search, search, search)
 	}
 	if opts.MFAEnabled != nil {
 		conditions = append(conditions, `mfa_enabled = ?`)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -731,7 +731,7 @@ type DayCount struct {
 type ListUsersOpts struct {
 	Limit         int
 	Offset        int
-	Search        string // optional email/name search
+	Search        string // optional id/email/name search
 	MFAEnabled    *bool  // filter by mfa_enabled
 	EmailVerified *bool  // filter by email_verified
 	RoleID        string // filter by role assignment


### PR DESCRIPTION
Title
Search admin users by id

Summary
- include user ids in the existing admin user-list search predicate
- keep the same parameterized query path for list results and totals
- add an API regression for an id-only search term

Addresses #80.

Validation
- `go test ./internal/api -run TestAdminListUsers -count=1`
- `go test ./internal/storage -count=1`
- `git diff --check HEAD~1 HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30`

Notes
- Before the source change, `go test ./internal/api -run TestAdminListUsers_SearchMatchesUserID -count=1` failed with `total: got 0, want 1`.
- I also tried `go test ./internal/api -count=1`; it failed in unrelated existing tests such as `TestFirstbootKeyServedOnceGlobally`, `TestAdminConfigShape`, `TestListAPIKeys`, and `TestScenario_SwarmOrchestrator`. The new user-search regression passed during that run.
- I did not run an admin UI build; this PR changes the backend search predicate and Go API coverage only.
